### PR TITLE
Use the same filename in zip and html - Fixes #10

### DIFF
--- a/Icinga2/icinga2ActionExecutor.py
+++ b/Icinga2/icinga2ActionExecutor.py
@@ -154,7 +154,7 @@ def create_html(is_service_alert, perf_data):
         buf += get_host_status_html()
 
     if perf_data:
-        buf += """<div class="img"><img src="perf_data.png"></div>"""
+        buf += """<div class="img"><img src="perfData.png"></div>"""
 
     buf += """
                 </div>


### PR DESCRIPTION
This should fix #10 by using the same filename in both the zip file and the html