### PR TITLE
Various Icinga2 scripts fixes for customer errors

### DIFF
--- a/Icinga2/conf/config.json
+++ b/Icinga2/conf/config.json
@@ -7,7 +7,8 @@
     "graphite_url": "http://localhost:5003",
     "api_url": "https://localhost:5665",
     "user": "icingaadmin",
-    "password": "icingaadmin"
+    "password": "icingaadmin",
+    "insecure": "false"
   },
   "actionMappings": {
     "Create": {

--- a/Icinga2/opsgenie-icinga2/opsgenie.conf
+++ b/Icinga2/opsgenie-icinga2/opsgenie.conf
@@ -3,7 +3,7 @@ object NotificationCommand "opsgenie-service-notification" {
 
   vars.hgns = {{ host.groups.join(",") }}
   vars.sgns = {{ service.groups.join(",") }}
-  command = [ "/home/opsgenie/oec/icinga2/send2opsgenie" ]
+  command = [ "/home/opsgenie/oec/opsgenie-icinga2/send2opsgenie" ]
   arguments = {
   "-entityType" = "service"
   "-t" = "$notification.type$"
@@ -55,7 +55,7 @@ object NotificationCommand "opsgenie-host-notification" {
   import "plugin-notification-command"
 
   vars.hgns = {{ host.groups.join(",") }}
-  command = [ "/home/opsgenie/oec/icinga2/send2opsgenie" ]
+  command = [ "/home/opsgenie/oec/opsgenie-icinga2/send2opsgenie" ]
   arguments = {
   "-entityType" = "host"
   "-t" = "$notification.type$"


### PR DESCRIPTION
1. Allow insecure `https` requests. Because `Icinga2` api generates a
   local certificate, `requests` isn't able to verify SSL. We can skip
   verification by passing `insecure` = `"true"` as a global flag
   to avoid request failure, such as:

   ```
   Aug 28 13:49:18 localhost.localdomain OpsgenieEdgeConnector[6755]: requests.exceptions.SSLError: HTTPSConnectionPool(host='localhost', port=5665): Max retries exceeded with url: /v1/actions/add-comment (Caused by SSLError(SSLCertVerificat ionError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate in certificate chain (_ssl.c:1108)')))
   ```

   Alternatively, we could also allow requests to use
   `/var/lib/icinga2/ca/ca.crt` as a certificate, but it may be OS
   dependent and we'll have to tweak OEC installation to ensure that
   this file is readable by `opsgenie` user.

2. Fix the accept header as expected by `Icinga2`. Otherwise, it results
   in an error such as:

   ```
   DEBUG:urllib3.connectionpool:https://localhost:5665 "POST /v1/actions/add-comment HTTP/1.1" 400 67
   WARNING:root:[AddNote] Could not execute at Icinga. Icinga Response: b"<h1>Accept header is missing or not set to 'application/json'.</h1>"
   ```

3. Fix the details zip path to be the same directory as the script. By
   default, the path `OEC` is using to write the details zip file may be
   not writable, resulting in:
   ```
   Aug 28 12:36:18 localhost.localdomain OpsgenieEdgeConnector[4194]: PermissionError: [Errno 13] Permission denied: 'details_2020_08_28_12_08_1598598378.zip'
   ```

JIRA: https://ifountain.atlassian.net/browse/HEIMDALL-5958