### PR TITLE
Cherwell - Updated retrieve_og_customer_id to search for "Full name" instead of "Full Name"

### DIFF
--- a/Cherwell/scripts/actionExecutor.py
+++ b/Cherwell/scripts/actionExecutor.py
@@ -377,7 +377,7 @@ def retrieve_og_customer_id():
         if response.status_code < 300 and response_body.get('fieldDefinitions'):
             full_name_field_map = None
             for field_definition in response_body.get('fieldDefinitions'):
-                if field_definition.get('displayName') == 'Full name':
+                if field_definition.get('displayName') == 'Full Name':
                     full_name_field_map = field_definition
                     break
             if full_name_field_map:


### PR DESCRIPTION
This PR fixes how actionExecutor.py searches for the internal customer name when creating an incident in Cherwell. Currently, it searches for a field "Full name" while the field is actually "Full **N**ame" out of the box in the current Cherwell release (v.10). 

Snippet returned from Cherwell's API for this field:
```
      "description": "The customer's full name including prefix, first, middle, last and suffix.",
      "details": "Full-text, Conditionally Read-only, Calculated",
      "displayName": "Full Name",
      "enabled": false,
      "fieldId": "BO:93405caa107c376a2bd15c4c8885a900be316f3a72,FI:9337c2322a087296f7322a481d8858300e3f6e1dbb",
      "hasDate": false,
```

