### PR TITLE
Use actual re.sub() regex-replace rather than str.replace(), since we…

### DIFF
--- a/Jira/scripts/actionExecutor.py
+++ b/Jira/scripts/actionExecutor.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import logging
 import sys
+import re
 
 import requests
 from requests.auth import HTTPBasicAuth
@@ -122,7 +123,7 @@ def main():
                 },
                 "summary": queue_message.get("summary"),
                 "description": queue_message.get("description"),
-                "labels": [toLabel.replace("\\s", "")]
+                "labels": [ re.sub('\s','',toLabel) ]
             }
         }
     elif mapped_action == "resolveIssue":


### PR DESCRIPTION
… want to eliminate all varieties of whitespace from the Labels sent to Jira.

I noticed that the code to make a Label out of the alias name was evidently intending to remove all whitespace from the name, since spaces are not permitted in a Label on the Jira side. However, the str.replace() function recognizes only static strings, not character classes or other regex constructs; it was looking for literally backslash-s in the original text, so it would not even remove spaces. Since the "re" module is in the core library in both Python 2.x and 3.x, I propose importing that and using re.sub(). Thanks!