### PR TITLE
Update so can login on zabbix 6.4.

### DIFF
--- a/Zabbix/scripts/actionExecutorForZabbix4.py
+++ b/Zabbix/scripts/actionExecutorForZabbix4.py
@@ -42,7 +42,7 @@ def login_to_zabbix(user, password, url):
         "jsonrpc": "2.0",
         "method": "user.login",
         "params": {
-            "user": user,
+            "username": user,
             "password": password
         },
         "id": 1


### PR DESCRIPTION
The "user" param has been deprecated for a long while now, and they recently disabled it entirely. It's "username" now.