### PR TITLE
Fix TypeError actionExecutor.py

### DIFF
--- a/Nagios/scripts/actionExecutor.py
+++ b/Nagios/scripts/actionExecutor.py
@@ -105,9 +105,9 @@ def get_image(url, entity):
     else:
         content = response.content
         logging.warning("Could not get image from url " + url + ".ResponseCode: " + str(
-            response.status_code) + "Reason: " + content)
+            response.status_code) + "Reason: " + str(content))
         print("Could not get image from url " + url + ".ResponseCode: " + str(
-            response.status_code) + "Reason: " + content)
+            response.status_code) + "Reason: " + str(content))
         return None
 
 


### PR DESCRIPTION
We currently get this error when the script tries to get the histogram image, but can't find it.
`Reason: Err: exit status 1, Stderr: Traceback (most recent call last): File "/home/opsgenie/oec/scripts/actionExecutor.py", line 418, in <module> main() File "/home/opsgenie/oec/scripts/actionExecutor.py", line 367, in main attach("service") File "/home/opsgenie/oec/scripts/actionExecutor.py", line 262, in attach alert_histogram = get_alert_histogram(entity) File "/home/opsgenie/oec/scripts/actionExecutor.py", line 116, in get_alert_histogram return get_image(url, entity) File "/home/opsgenie/oec/scripts/actionExecutor.py", line 108, in get_image response.status_code) + "Reason: " + content) TypeError: must be str, not bytes`

The 'response.content' that is returned is in a binary format, which gives a TypeError when it tries to log/print the warning message that the image can not be found. 

This PR fixes the TypeError by formatting the content to a string first.